### PR TITLE
Gitleaks fixes

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,3 +23,6 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         with:
           args: "--verbose --redact --config=.gitleaks.toml"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAK_LICENSE }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -3,10 +3,10 @@ name: Gitleaks Scan
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   gitleaks:
@@ -15,7 +15,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
Use gitleaks license, github token and use checkout v4. Also change depth of gitleaks to 0 so it can use all git history